### PR TITLE
Sort the games on the date the games ended.

### DIFF
--- a/ogsdownloader/__main__.py
+++ b/ogsdownloader/__main__.py
@@ -40,6 +40,7 @@ def add_arguments(parser: argparse.ArgumentParser):
     parser.add_argument('-c', '--config', default=None)
     parser.add_argument('-f', '--format', type=str, default='{ID}')
     parser.add_argument('-i', '--interactive', action='store_true')
+    parser.add_argument('-p', '--page', type=int, default=1)
     parser.add_argument('-s', '--sleep', type=int, default=5)
     parser.add_argument('-u', '--user-id', action='append', default=[])
     parser.add_argument('-v', '--verbose', action='count', default=0)
@@ -106,7 +107,7 @@ def main(args: argparse.Namespace):
                 logger.error(e)
                 continue
 
-        player.download_games_from_user_id(user, args.destination, args.format)
+        player.download_games_from_user_id(user, args.destination, args.format, args.page)
 
     player.config.remove_option('DEFAULT', 'password')
     with open(config_file_location, 'w') as file:

--- a/ogsdownloader/oauth2.py
+++ b/ogsdownloader/oauth2.py
@@ -7,7 +7,9 @@ from configparser import ConfigParser
 from urllib.parse import urlencode
 
 import requests
-from requests import JSONDecodeError
+
+import json
+from json import JSONDecodeError
 
 from ogsdownloader.exceptions import AuthenticationError
 

--- a/ogsdownloader/player.py
+++ b/ogsdownloader/player.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # coding=utf-8
 
-import json
 import logging
 import time
 from configparser import ConfigParser
@@ -47,9 +46,9 @@ class Player:
         except KeyError:
             raise OGSDownloaderException(f'No user found to match username {username}')
 
-    def get_games_from_user_id(self, user_id: int) -> list[dict]:
+    def get_games_from_user_id(self, user_id: int, page: int) -> list[dict]:
         results = []
-        url = f'http://online-go.com/api/v1/players/{user_id}/games?page_size=50'
+        url = f'http://online-go.com/api/v1/players/{user_id}/games?page_size=10&ordering=ended&page={page}'
         while True:
             logger.debug(f'Requesting page {url} to get game data')
             response = self.make_request(url)
@@ -65,8 +64,8 @@ class Player:
                 time.sleep(self.sleep_time)
         return results
 
-    def download_games_from_user_id(self, user_id: int, destination: Path, format_string: str):
-        data = self.get_games_from_user_id(user_id)
+    def download_games_from_user_id(self, user_id: int, destination: Path, format_string: str, page: int):
+        data = self.get_games_from_user_id(user_id, page)
         logger.debug(f'Found details of {len(data)} games')
         games = [Game(d) for d in data]
         logger.info(f'Found {len(games)} games for user id {user_id}')


### PR DESCRIPTION
Add the option -p/--page to select page to start at.

In the API call to OGS it now have ordering=ended. This makes the games come in the same order every time.

And the -p option makes it possible to start download at a specific page. This makes is possible to later only download games that are newer.